### PR TITLE
Make it easier to use different TestRunner class

### DIFF
--- a/src/com/zutubi/android/junitreport/JUnitReportTestRunner.java
+++ b/src/com/zutubi/android/junitreport/JUnitReportTestRunner.java
@@ -124,9 +124,14 @@ public class JUnitReportTestRunner extends InstrumentationTestRunner {
         }
     }
 
+	/** you can subclass and override this if you want to use a different TestRunner */
+	protected AndroidTestRunner makeAndroidTestRunner() {
+		return new AndroidTestRunner();
+	}
+	
     @Override
     protected AndroidTestRunner getAndroidTestRunner() {
-        AndroidTestRunner runner = new AndroidTestRunner();
+        AndroidTestRunner runner = makeAndroidTestRunner();
         mListener = new JUnitReportListener(getContext(), getTargetContext(), mReportFile, mReportDir, mFilterTraces, mMultiFile);
         runner.addTestListener(mListener);
         return runner;


### PR DESCRIPTION
Hi,

the attached pull request contains changes to make it easier to use a class other than AndroidTestRunner for the TestRunner.

Thanks
Simon
