### PR TITLE
Fix build warnings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,7 @@
     </target>
     
     <target name="compile" depends="-init">
-        <javac target="1.5" source="1.5" debug="true" destdir="${classes.dir}" classpath="${android.jar}">
+        <javac target="1.5" source="1.5" debug="true" destdir="${classes.dir}" classpath="${android.jar}" includeantruntime="false">
             <src path="${source.dir}"/>
         </javac>
     </target>


### PR DESCRIPTION
This fixes a few warnings when building an Mac OS X using Oracle's Java 1.7.0_04 and Ant 1.8.2.
