### PR TITLE
Don't use deprecated MODE_WORLD_READABLE

### DIFF
--- a/src/com/zutubi/android/junitreport/JUnitReportListener.java
+++ b/src/com/zutubi/android/junitreport/JUnitReportListener.java
@@ -201,7 +201,7 @@ public class JUnitReportListener implements TestListener {
     private FileOutputStream openOutputStream(String fileName) throws IOException {
         if (mReportDir == null) {
             Log.d(LOG_TAG, "No reportDir specified. Opening report file '" + fileName + "' in internal storage of app under test");
-            return mTargetContext.openFileOutput(fileName, Context.MODE_WORLD_READABLE);
+            return mTargetContext.openFileOutput(fileName, Context.MODE_PRIVATE);
         } else {
             if (mReportDir.contains(TOKEN_EXTERNAL)) {
                 File externalDir = Compatibility.getExternalFilesDir(mTargetContext, null);


### PR DESCRIPTION
MODE_WORLD_READABLE was deprecated since Android API 17 and throws SecurityException starting from API 24:
https://developer.android.com/reference/android/content/Context.html#MODE_WORLD_READABLE